### PR TITLE
feat: add support for squash merge commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This plugin supports the following GitHub merge strategies:
 - **Merge commit**: Commits with title `Merge pull request #123 from ...`
 - **Squash and merge**: Commits with title ending in `(#123)` (GitHub's default squash merge format)
 
+**Note**: Custom merge commit titles are not supported. The plugin relies on GitHub's default merge commit formats to extract PR numbers. If you modify the merge commit title when merging, the plugin will not be able to associate the commit with a pull request.
+
 ## Configuration
 
 Make sure there is a valid `GITHUB_TOKEN` that has at least `contents: read` rights.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ With this example:
 - merged pull requests with label `documentation` will result in a `patch` release.
 - merged pull requests with label `bug` will result in a `patch` release.
 
-Note that this plugin will only associate pull requests with the merge-commit title `Merged pull request #XXX from`. This is the default merge-commit title that GitHub uses for non-squash, non-rebase merges.
+### Supported merge strategies
+
+This plugin supports the following GitHub merge strategies:
+
+- **Merge commit**: Commits with title `Merge pull request #123 from ...`
+- **Squash and merge**: Commits with title ending in `(#123)` (GitHub's default squash merge format)
 
 ## Configuration
 

--- a/index.js
+++ b/index.js
@@ -90,12 +90,30 @@ function getRepositoryInfo(pluginConfig, context) {
   );
 }
 
+function extractPullRequestNumber(commit) {
+  // Pattern 1: Normal merge commit - "Merge pull request #123 from ..."
+  const normalMergeMatch = /^Merge pull request #(\d+) from/.exec(
+    commit.subject
+  );
+  if (normalMergeMatch) {
+    return parseInt(normalMergeMatch[1], 10);
+  }
+
+  // Pattern 2: Squash merge - "Title (#123)"
+  // GitHub's default squash merge format appends the PR number at the end
+  const squashMergeMatch = /\(#(\d+)\)\s*$/.exec(commit.subject);
+  if (squashMergeMatch) {
+    return parseInt(squashMergeMatch[1], 10);
+  }
+
+  return null;
+}
+
 async function getPullRequestInfo({ fetchGitHubApi, owner, repo, commit }) {
-  const match = /^Merge pull request #(\d+) from/.exec(commit.subject);
-  if (!match) {
+  const pullRequestNumber = extractPullRequestNumber(commit);
+  if (!pullRequestNumber) {
     return;
   }
-  const pullRequestNumber = parseInt(match[1], 10);
   const pullRequestInfo = await fetchGitHubApi(
     `/repos/${owner}/${repo}/pulls/${pullRequestNumber}`
   );

--- a/index.js
+++ b/index.js
@@ -90,18 +90,16 @@ function getRepositoryInfo(pluginConfig, context) {
   );
 }
 
-function extractPullRequestNumber(commit) {
+export function extractPullRequestNumber(subject) {
   // Pattern 1: Normal merge commit - "Merge pull request #123 from ..."
-  const normalMergeMatch = /^Merge pull request #(\d+) from/.exec(
-    commit.subject
-  );
+  const normalMergeMatch = /^Merge pull request #(\d+) from/.exec(subject);
   if (normalMergeMatch) {
     return parseInt(normalMergeMatch[1], 10);
   }
 
   // Pattern 2: Squash merge - "Title (#123)"
   // GitHub's default squash merge format appends the PR number at the end
-  const squashMergeMatch = /\(#(\d+)\)\s*$/.exec(commit.subject);
+  const squashMergeMatch = /\(#(\d+)\)\s*$/.exec(subject);
   if (squashMergeMatch) {
     return parseInt(squashMergeMatch[1], 10);
   }
@@ -110,7 +108,7 @@ function extractPullRequestNumber(commit) {
 }
 
 async function getPullRequestInfo({ fetchGitHubApi, owner, repo, commit }) {
-  const pullRequestNumber = extractPullRequestNumber(commit);
+  const pullRequestNumber = extractPullRequestNumber(commit.subject);
   if (!pullRequestNumber) {
     return;
   }

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+
+// Extract the function for testing (we'll inline it here since it's not exported)
+function extractPullRequestNumber(commit) {
+  // Pattern 1: Normal merge commit - "Merge pull request #123 from ..."
+  const normalMergeMatch = /^Merge pull request #(\d+) from/.exec(
+    commit.subject
+  );
+  if (normalMergeMatch) {
+    return parseInt(normalMergeMatch[1], 10);
+  }
+
+  // Pattern 2: Squash merge - "Title (#123)"
+  const squashMergeMatch = /\(#(\d+)\)\s*$/.exec(commit.subject);
+  if (squashMergeMatch) {
+    return parseInt(squashMergeMatch[1], 10);
+  }
+
+  return null;
+}
+
+describe("extractPullRequestNumber", () => {
+  it("extracts PR number from normal merge commit", () => {
+    const commit = { subject: "Merge pull request #123 from feature/branch" };
+    assert.strictEqual(extractPullRequestNumber(commit), 123);
+  });
+
+  it("extracts PR number from squash merge commit", () => {
+    const commit = { subject: "feat: add new feature (#456)" };
+    assert.strictEqual(extractPullRequestNumber(commit), 456);
+  });
+
+  it("extracts PR number from squash merge with complex title", () => {
+    const commit = {
+      subject: "[#144] Remove v prefix from semantic-release tags (#143)",
+    };
+    assert.strictEqual(extractPullRequestNumber(commit), 143);
+  });
+
+  it("returns null for regular commits without PR reference", () => {
+    const commit = { subject: "fix: update dependencies" };
+    assert.strictEqual(extractPullRequestNumber(commit), null);
+  });
+
+  it("returns null for commits with issue reference in middle", () => {
+    const commit = { subject: "fix issue #123 in module" };
+    assert.strictEqual(extractPullRequestNumber(commit), null);
+  });
+
+  it("handles PR number with trailing whitespace", () => {
+    const commit = { subject: "feat: add feature (#789)  " };
+    assert.strictEqual(extractPullRequestNumber(commit), 789);
+  });
+});

--- a/index.test.js
+++ b/index.test.js
@@ -1,55 +1,35 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-
-// Extract the function for testing (we'll inline it here since it's not exported)
-function extractPullRequestNumber(commit) {
-  // Pattern 1: Normal merge commit - "Merge pull request #123 from ..."
-  const normalMergeMatch = /^Merge pull request #(\d+) from/.exec(
-    commit.subject
-  );
-  if (normalMergeMatch) {
-    return parseInt(normalMergeMatch[1], 10);
-  }
-
-  // Pattern 2: Squash merge - "Title (#123)"
-  const squashMergeMatch = /\(#(\d+)\)\s*$/.exec(commit.subject);
-  if (squashMergeMatch) {
-    return parseInt(squashMergeMatch[1], 10);
-  }
-
-  return null;
-}
+import { extractPullRequestNumber } from "./index.js";
 
 describe("extractPullRequestNumber", () => {
   it("extracts PR number from normal merge commit", () => {
-    const commit = { subject: "Merge pull request #123 from feature/branch" };
-    assert.strictEqual(extractPullRequestNumber(commit), 123);
+    const subject = "Merge pull request #123 from feature/branch";
+    assert.strictEqual(extractPullRequestNumber(subject), 123);
   });
 
   it("extracts PR number from squash merge commit", () => {
-    const commit = { subject: "feat: add new feature (#456)" };
-    assert.strictEqual(extractPullRequestNumber(commit), 456);
+    const subject = "feat: add new feature (#456)";
+    assert.strictEqual(extractPullRequestNumber(subject), 456);
   });
 
   it("extracts PR number from squash merge with complex title", () => {
-    const commit = {
-      subject: "[#144] Remove v prefix from semantic-release tags (#143)",
-    };
-    assert.strictEqual(extractPullRequestNumber(commit), 143);
+    const subject = "[#144] Remove v prefix from semantic-release tags (#143)";
+    assert.strictEqual(extractPullRequestNumber(subject), 143);
   });
 
   it("returns null for regular commits without PR reference", () => {
-    const commit = { subject: "fix: update dependencies" };
-    assert.strictEqual(extractPullRequestNumber(commit), null);
+    const subject = "fix: update dependencies";
+    assert.strictEqual(extractPullRequestNumber(subject), null);
   });
 
   it("returns null for commits with issue reference in middle", () => {
-    const commit = { subject: "fix issue #123 in module" };
-    assert.strictEqual(extractPullRequestNumber(commit), null);
+    const subject = "fix issue #123 in module";
+    assert.strictEqual(extractPullRequestNumber(subject), null);
   });
 
   it("handles PR number with trailing whitespace", () => {
-    const commit = { subject: "feat: add feature (#789)  " };
-    assert.strictEqual(extractPullRequestNumber(commit), 789);
+    const subject = "feat: add feature (#789)  ";
+    assert.strictEqual(extractPullRequestNumber(subject), 789);
   });
 });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/bobvanderlinden/semantic-release-pull-request-analyzer.git"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "license": "MIT",
   "homepage": "https://github.com/bobvanderlinden/semantic-release-pull-request-analyzer",
   "exports": "./index.js",


### PR DESCRIPTION
## Summary

This PR adds support for GitHub's squash merge strategy in addition to the existing normal merge commit support.

Currently, the plugin only detects commits with the format `Merge pull request #123 from ...`, which is used by GitHub's "Create a merge commit" strategy. However, many projects prefer using "Squash and merge", which creates commits with the format `Title (#123)`.

### Changes

- **New `extractPullRequestNumber()` function** - Handles both merge patterns:
  - Normal merge: `Merge pull request #123 from ...`
  - Squash merge: `Title (#123)` (PR number at the end)
- **Unit tests** - Added tests using Node.js built-in test runner (no new dependencies)
- **Updated README** - Documented the supported merge strategies

### Example commit formats now supported

| Merge Strategy | Example Commit Subject |
|----------------|------------------------|
| Merge commit | `Merge pull request #123 from feature/branch` |
| Squash and merge | `feat: add new feature (#123)` |
| Squash and merge | `[#144] Remove v prefix from tags (#143)` |

## Test plan

- [x] All 6 unit tests pass (`npm test`)
- [x] Tested with a real project using squash merge commits